### PR TITLE
target_vault_name reference a resource not a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-<a name="unreleased"></a>
-## [Unreleased]
-
-- Fix target_vault_name should be referencing a resource and not a variable
-- Add comment for depends_on
-- Use resource and not variable for 'depends_on'
-- Add changelog
-- Add depends on to fix the occasional race condition
-
-
 <a name="1.0.0"></a>
 ## 1.0.0 - 2020-11-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="unreleased"></a>
+## [Unreleased]
+
+- Add depends on to fix the occasional race condition
+
+
+<a name="1.0.0"></a>
+## 1.0.0 - 2020-11-09
+
+- Complete AWS Backup module ([#1](https://github.com/umotif-public/terraform-aws-backup/issues/1))
+- Initial commit
+
+
+[Unreleased]: https://github.com/umotif-public/terraform-aws-backup/compare/1.0.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+- Fix target_vault_name should be referencing a resource and not a variable
+- Add comment for depends_on
+- Use resource and not variable for 'depends_on'
+- Add changelog
 - Add depends on to fix the occasional race condition
 
 

--- a/examples/external-vault/main.tf
+++ b/examples/external-vault/main.tf
@@ -106,4 +106,6 @@ module "backup" {
   tags = {
     Environment = "test"
   }
+
+  depends_on = [aws_backup_vault.external_vault]
 }

--- a/examples/one-db/main.tf
+++ b/examples/one-db/main.tf
@@ -168,7 +168,6 @@ module "backup" {
   rules = [
     {
       name              = "test-backup-rule"
-      target_vault_name = "test-rds-aurora"
       schedule          = "cron(0 12 * * ? *)"
       start_window      = "65"
       completion_window = "180"

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,7 @@ resource "aws_backup_plan" "main" {
 
   tags = var.tags
 
+  # There is on occasion where the vault is not created before the plan is being attempted to be created. This depends on is here to fix that 'race condition'.
   depends_on = [aws_backup_vault.main]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "aws_backup_plan" "main" {
 
   tags = var.tags
 
-  depends_on = [var.vault_name]
+  depends_on = [aws_backup_vault.main]
 }
 
 #####

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "aws_backup_plan" "main" {
     for_each = var.rules
     content {
       rule_name           = lookup(rule.value, "name")
-      target_vault_name   = lookup(rule.value, "target_vault_name", null) == null ? aws_backup_vault.main.name : lookup(rule.value, "target_vault_name", "Default")
+      target_vault_name   = lookup(rule.value, "target_vault_name", null) == null ? aws_backup_vault.main[0].name : lookup(rule.value, "target_vault_name", "Default")
       schedule            = lookup(rule.value, "schedule", null)
       start_window        = lookup(rule.value, "start_window", null)
       completion_window   = lookup(rule.value, "completion_window", null)

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "aws_backup_plan" "main" {
     for_each = var.rules
     content {
       rule_name           = lookup(rule.value, "name")
-      target_vault_name   = lookup(rule.value, "target_vault_name", "Default")
+      target_vault_name   = var.vault_name != null ? aws_backup_vault.main[0].name : lookup(rule.value, "target_vault_name", "Default")
       schedule            = lookup(rule.value, "schedule", null)
       start_window        = lookup(rule.value, "start_window", null)
       completion_window   = lookup(rule.value, "completion_window", null)
@@ -59,8 +59,6 @@ resource "aws_backup_plan" "main" {
   }
 
   tags = var.tags
-
-  depends_on = [aws_backup_vault.main]
 }
 
 #####

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "aws_backup_plan" "main" {
     for_each = var.rules
     content {
       rule_name           = lookup(rule.value, "name")
-      target_vault_name   = lookup(rule.value, "target_vault_name", null) == null ? var.vault_name : lookup(rule.value, "target_vault_name", "Default")
+      target_vault_name   = lookup(rule.value, "target_vault_name", null) == null ? aws_backup_vault.main.name : lookup(rule.value, "target_vault_name", "Default")
       schedule            = lookup(rule.value, "schedule", null)
       start_window        = lookup(rule.value, "start_window", null)
       completion_window   = lookup(rule.value, "completion_window", null)
@@ -59,9 +59,6 @@ resource "aws_backup_plan" "main" {
   }
 
   tags = var.tags
-
-  # There is on occasion where the vault is not created before the plan is being attempted to be created. This depends on is here to fix that 'race condition'.
-  depends_on = [aws_backup_vault.main]
 }
 
 #####

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,8 @@ resource "aws_backup_plan" "main" {
   }
 
   tags = var.tags
+
+  depends_on = [var.vault_name]
 }
 
 #####

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "aws_backup_plan" "main" {
     for_each = var.rules
     content {
       rule_name           = lookup(rule.value, "name")
-      target_vault_name   = lookup(rule.value, "target_vault_name", null) == null ? aws_backup_vault.main[0].name : lookup(rule.value, "target_vault_name", "Default")
+      target_vault_name   = lookup(rule.value, "target_vault_name", "Default")
       schedule            = lookup(rule.value, "schedule", null)
       start_window        = lookup(rule.value, "start_window", null)
       completion_window   = lookup(rule.value, "completion_window", null)
@@ -59,6 +59,8 @@ resource "aws_backup_plan" "main" {
   }
 
   tags = var.tags
+
+  depends_on = [aws_backup_vault.main]
 }
 
 #####


### PR DESCRIPTION
# Description

This change is to deal with a race condition problem that occurs on occasion as well as deal with the expression used for `target_vault_name`.  