### PR TITLE
Allow for multiple selection conditions for a backup plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,19 @@ module "backup" {
     }
   ]
 
-  selections = [
-    {
-      name = "test-backup-selection"
-      resources = [
-        "arn:aws:rds:eu-west-1:1111111111:cluster:example-database-1"
-      ]
+  selection_name = "test-backup-selection"
+  selection_resources = ["arn:aws:rds:eu-west-1:1111111111:cluster:example-dataabase-1"]
 
-      selection_tag = {
-        type  = "STRINGEQUALS"
-        key   = "Environment"
-        value = "test"
-      }
+  selection_tags = [
+    {
+      type  = "STRINGEQUALS"
+      key   = "Project"
+      value = "Test"
+    },
+    {
+      type  = "STRINGEQUALS"
+      key   = "Environment"
+      value = "test"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Module managed by:
 | selection\_tag\_key | The key in a key-value pair | `string` | `null` | no |
 | selection\_tag\_type | An operation, such as StringEquals, that is applied to a key-value pair used to filter resources in a selection | `string` | `null` | no |
 | selection\_tag\_value | The value in a key-value pair | `string` | `null` | no |
+| selection\_tags | A list of selection tags map | `list` | `[]` | no |
 | selections | A list of selection maps | `list` | `[]` | no |
 | tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
 | vault\_kms\_key\_arn | The server-side encryption key that is used to protect your backups | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ Module managed by:
 | selection\_tag\_type | An operation, such as StringEquals, that is applied to a key-value pair used to filter resources in a selection | `string` | `null` | no |
 | selection\_tag\_value | The value in a key-value pair | `string` | `null` | no |
 | selection\_tags | A list of selection tags map | `list` | `[]` | no |
-| selections | A list of selection maps | `list` | `[]` | no |
 | tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
 | vault\_kms\_key\_arn | The server-side encryption key that is used to protect your backups | `string` | `null` | no |
 | vault\_name | Name of the backup vault to create. If not given, AWS use default | `string` | `null` | no |

--- a/examples/external-vault/main.tf
+++ b/examples/external-vault/main.tf
@@ -92,14 +92,18 @@ module "backup" {
     }
   ]
 
-  selections = [
+  selection_name = "test-backup-selection"
+
+  selection_tags = [
     {
-      name = "test-backup-selection"
-      selection_tag = {
-        type  = "STRINGEQUALS"
-        key   = "Environment"
-        value = "test"
-      }
+      type  = "STRINGEQUALS"
+      key   = "Project"
+      value = "Test"
+    },
+    {
+      type  = "STRINGEQUALS"
+      key   = "Environment"
+      value = "test"
     }
   ]
 

--- a/examples/multiple-dbs/main.tf
+++ b/examples/multiple-dbs/main.tf
@@ -194,7 +194,7 @@ module "backup" {
       target_vault_name = "test-rds-aurora"
       schedule          = "cron(0 12 * * ? *)"
       start_window      = "65"
-      completion_window = "180"
+      completion_window = "190"
       recovery_point_tags = {
         Project = "test"
         Region  = "eu-west-1"
@@ -207,19 +207,22 @@ module "backup" {
     }
   ]
 
-  selections = [
-    {
-      name = "test-backup-selection"
-      resources = [
-        module.aurora-mysql.rds_cluster_arn,
-        module.aurora-postgresql.rds_cluster_arn
-      ]
+  selection_name = "test-backup-selection"
+  selection_resources = [
+    module.aurora-mysql.rds_cluster_arn,
+    module.aurora-postgresql.rds_cluster_arn
+  ]
 
-      selection_tag = {
-        type  = "STRINGEQUALS"
-        key   = "Environment"
-        value = "test"
-      }
+  selection_tags = [
+    {
+      type  = "STRINGEQUALS"
+      key   = "Project"
+      value = "Test"
+    },
+    {
+      type  = "STRINGEQUALS"
+      key   = "Environment"
+      value = "test"
     }
   ]
 }

--- a/examples/one-db/main.tf
+++ b/examples/one-db/main.tf
@@ -183,18 +183,19 @@ module "backup" {
     }
   ]
 
-  selections = [
-    {
-      name = "test-backup-selection"
-      resources = [
-        module.aurora.rds_cluster_arn
-      ]
+  selection_name      = "test-backup-selection"
+  selection_resources = [module.aurora.rds_cluster_arn]
 
-      selection_tag = {
-        type  = "STRINGEQUALS"
-        key   = "Environment"
-        value = "test"
-      }
+  selection_tags = [
+    {
+      type  = "STRINGEQUALS"
+      key   = "Project"
+      value = "Test"
+    },
+    {
+      type  = "STRINGEQUALS"
+      key   = "Environment"
+      value = "int"
     }
   ]
 }

--- a/examples/one-db/main.tf
+++ b/examples/one-db/main.tf
@@ -195,7 +195,7 @@ module "backup" {
     {
       type  = "STRINGEQUALS"
       key   = "Environment"
-      value = "int"
+      value = "test"
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -65,16 +65,14 @@ resource "aws_backup_plan" "main" {
 # Backup Selection
 #####
 resource "aws_backup_selection" "main" {
-  count = length(var.selections) >= 1 ? length(var.selections) : 0
-
   iam_role_arn = aws_iam_role.main.arn
-  name         = lookup(element(var.selections, count.index), "name", null)
+  name         = var.selection_name
   plan_id      = aws_backup_plan.main.id
 
-  resources = lookup(element(var.selections, count.index), "resources", null)
+  resources = var.selection_resources
 
   dynamic "selection_tag" {
-    for_each = length(lookup(element(var.selections, count.index), "selection_tags", {})) == 0 ? [] : [lookup(element(var.selections, count.index), "selection_tags", {})]
+    for_each = var.selection_tags
     content {
       type  = lookup(selection_tag.value, "type", null)
       key   = lookup(selection_tag.value, "key", null)

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "aws_backup_selection" "main" {
   resources = lookup(element(var.selections, count.index), "resources", null)
 
   dynamic "selection_tag" {
-    for_each = length(lookup(element(var.selections, count.index), "selection_tag", {})) == 0 ? [] : [lookup(element(var.selections, count.index), "selection_tag", {})]
+    for_each = length(lookup(element(var.selections, count.index), "selection_tags", {})) == 0 ? [] : [lookup(element(var.selections, count.index), "selection_tags", {})]
     content {
       type  = lookup(selection_tag.value, "type", null)
       key   = lookup(selection_tag.value, "key", null)

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,12 @@ variable "selections" {
   default     = []
 }
 
+variable "selection_tags" {
+  description = "A list of selection tags map"
+  type        = list
+  default     = []
+}
+
 #
 # AWS Backup vault
 #

--- a/variables.tf
+++ b/variables.tf
@@ -42,12 +42,6 @@ variable "selection_tag_value" {
   default     = null
 }
 
-variable "selections" {
-  description = "A list of selection maps"
-  type        = list
-  default     = []
-}
-
 variable "selection_tags" {
   description = "A list of selection tags map"
   type        = list


### PR DESCRIPTION
# Description

This change is about altering how selection conditions work. Instead of creating a number of selection resources for each new tag, that has now adapted so that multiple tags can be created in just one selection resource.

The impact of this change allows 'AND' based conditions to be created for each backup plan created rather than an 'OR' based conditions, as such was the case in the first release of this module.